### PR TITLE
Core - Fix infinite Shorten of Ropes

### DIFF
--- a/addons/core/functions/fnc_canShortenRopes.sqf
+++ b/addons/core/functions/fnc_canShortenRopes.sqf
@@ -15,14 +15,11 @@
  * Public: No
  */
 
-params ["_vehicle"];
+params ["_vehicle", ["_ropeIndex", 0, [0]]];
 
-private _allCargo = _vehicle getVariable [QGVAR(cargo), []];
-private _canShorten = true;
+private _cargo = [_vehicle, _ropeIndex] call FUNC(getCargo);
 
-{
-    if (_x distance _vehicle < 10) then { _canShorten = false; };
-} forEach _allCargo;
+if (_cargo distance _vehicle < 10) exitWith { false; };
 
 if (ACE_player distance _vehicle > 10) exitWith { false };
 
@@ -34,4 +31,4 @@ if ((count _existingRopes) == 0) exitWith { false };
 private _activeRopes = [_vehicle] call FUNC(getActiveRopes);
 if ((count _activeRopes) == 0) exitWith { false };
 
-_canShorten
+true

--- a/addons/core/functions/fnc_canShortenRopes.sqf
+++ b/addons/core/functions/fnc_canShortenRopes.sqf
@@ -17,6 +17,12 @@
 
 params ["_vehicle"];
 
+private _allCargo = _vehicle getVariable [QGVAR(cargo), []];
+
+{
+    if _x distance _vehicle < 10 exitWith { false; };
+} forEach _allCargo;
+
 if (ACE_player distance _vehicle > 10) exitWith { false };
 
 if !([_vehicle] call FUNC(isSupportedVehicle)) exitWith { false };

--- a/addons/core/functions/fnc_canShortenRopes.sqf
+++ b/addons/core/functions/fnc_canShortenRopes.sqf
@@ -18,9 +18,10 @@
 params ["_vehicle"];
 
 private _allCargo = _vehicle getVariable [QGVAR(cargo), []];
+private _canShorten = true;
 
 {
-    if (_x distance _vehicle < 10) exitWith { false; };
+    if (_x distance _vehicle < 10) then { _canShorten = false; };
 } forEach _allCargo;
 
 if (ACE_player distance _vehicle > 10) exitWith { false };
@@ -33,4 +34,4 @@ if ((count _existingRopes) == 0) exitWith { false };
 private _activeRopes = [_vehicle] call FUNC(getActiveRopes);
 if ((count _activeRopes) == 0) exitWith { false };
 
-true;
+_canShorten

--- a/addons/core/functions/fnc_canShortenRopes.sqf
+++ b/addons/core/functions/fnc_canShortenRopes.sqf
@@ -20,7 +20,7 @@ params ["_vehicle"];
 private _allCargo = _vehicle getVariable [QGVAR(cargo), []];
 
 {
-    if _x distance _vehicle < 10 exitWith { false; };
+    if (_x distance _vehicle < 10) exitWith { false; };
 } forEach _allCargo;
 
 if (ACE_player distance _vehicle > 10) exitWith { false };

--- a/addons/core/functions/fnc_shortenRopesIndexAction.sqf
+++ b/addons/core/functions/fnc_shortenRopesIndexAction.sqf
@@ -19,4 +19,4 @@ params ["_ropeIndex"];
 
 private _vehicle = ACE_player getVariable [QGVAR(shorten_Index_Vehicle), objNull];
 
-if ( _ropeIndex >= 0 && { !isNull _vehicle && { [_vehicle] call FUNC(canShortenRopes) } } ) then { [_vehicle, ACE_player, _ropeIndex] call FUNC(shortenRopes); };
+if ( _ropeIndex >= 0 && { !isNull _vehicle && { [_vehicle, _ropeIndex] call FUNC(canShortenRopes) } } ) then { [_vehicle, ACE_player, _ropeIndex] call FUNC(shortenRopes); };

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -3,4 +3,4 @@
 #define PATCH 0
 
 
-#define BUILD 42
+#define BUILD 44

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -3,4 +3,4 @@
 #define PATCH 0
 
 
-#define BUILD 44
+#define BUILD 42


### PR DESCRIPTION
## When merged this pull request will:

- title
- fixes #17

## Important

- [x] If the contribution affects [the documentation](../docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/Andx667/advanced_slingloading_redux/blob/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.

<!-- Known issues that need to be addressed -->
## Known Issues

- [ ] If atleast on cargo rope can be shortend, the sub menu for shortening all/front/center/rear still appears - probably fixed by using Ace Actions later
